### PR TITLE
Limit to 10 Arena images to improve Ecograder score

### DIFF
--- a/src/_data/arena.js
+++ b/src/_data/arena.js
@@ -55,10 +55,11 @@ const getArenaChannels = async (channelId) => {
       const newChannel = arena.channel(id);
       // get all content for this channel
       const content = await getAllContent(newChannel, per, length);
-      // get thumbnail urls for image blocks in this channel
+      // get thumbnail urls for image blocks in this channel (limited to 10 images)
       const images = content.reverse()
         .filter(b => !!b.image)
-        .map(b => b.image.thumb.url);
+        .map(b => b.image.thumb.url)
+        .slice(0, 10);
       // get channel description (if present)
       const description = metadata && metadata.description;
       // get channel url

--- a/src/_includes/assets/css/components.blocks.css
+++ b/src/_includes/assets/css/components.blocks.css
@@ -61,6 +61,7 @@
   max-height: 3.75rem;
   padding-bottom: 0.625rem;
   padding-right: 0.625rem;
+  min-height: 60px; /* match to height of images to stop "pop" */
 }
 
 .block__arrow {


### PR DESCRIPTION
Fixes #65 by limiting the number of Arena images as per @piperhaywood's suggestion.

Combining this with the upcoming PR to address #11 should drastically improve the Ecograder score and overall page load performance.